### PR TITLE
 Dynamic page size

### DIFF
--- a/src/treemenu.jl
+++ b/src/treemenu.jl
@@ -11,12 +11,14 @@ mutable struct TreeMenu{N<:Node} <: TerminalMenus._ConfiguredMenu{TerminalMenus.
     chosen::Bool   # when true, indicates that `current` was chosen by user
     # Needed by REPL.TerminalMenus
     pagesize::Int
+    dynamic::Bool
+    maxsize::Int
     pageoffset::Int
     config::TerminalMenus.Config
 end
-function TreeMenu(root; pagesize::Int=10, kwargs...)
+function TreeMenu(root; pagesize::Int=10, dynamic = false, maxsize = pagesize, kwargs...)
     pagesize = min(pagesize, count_open_leaves(root))
-    return TreeMenu(root, root, 1, 1, 1, false, pagesize, 0, TerminalMenus.Config(kwargs...))
+    return TreeMenu(root, root, 1, 1, 1, false, pagesize, dynamic, maxsize, 0, TerminalMenus.Config(kwargs...))
 end
 
 """
@@ -116,6 +118,9 @@ function TerminalMenus.keypress(menu::TreeMenu, i::UInt32)
     if i == Int(' ')
         node = setcurrent!(menu, menu.cursoridx)
         node.foldchildren = !node.foldchildren
+        if menu.dynamic
+            menu.pagesize = min(menu.maxsize, count_open_leaves(menu.root))
+        end
     end
     return false
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,5 +211,60 @@ if isdefined(FoldingTrees, :TreeMenu)
         @test TerminalMenus.selected(menu) == child1b
         TerminalMenus.cancel(menu)
         @test TerminalMenus.selected(menu) === nothing
+
+        # Dynamic `pagesize` when (un)folding:
+        foreach(unfold!, nodes(root))
+
+        menu = TreeMenu(root; dynamic = true)
+        state = TerminalMenus.printmenu(io, menu, 2; init = true)
+        str = String(take!(io))
+        nback, lines = linesplitter(str)
+        @test nback == 0
+        @test length(lines) == 8
+        @test lines[2] == " >    1"
+        @test menu.pagesize == 8
+
+        # pagesize shrink
+        TerminalMenus.keypress(menu, UInt32(' '))
+        state = TerminalMenus.printmenu(io, menu, 2; init = true)
+        str = String(take!(io))
+        nback, lines = linesplitter(str)
+        @test length(lines) == 3
+        @test lines[2] == " > +  1"
+        @test lines[3] == "      2"
+        @test menu.pagesize == 3
+
+        # pagesize regrow
+        TerminalMenus.keypress(menu, UInt32(' '))
+        state = TerminalMenus.printmenu(io, menu, 2; init = true)
+        str = String(take!(io))
+        nback, lines = linesplitter(str)
+        @test length(lines) == 8
+        @test lines[2] == " >    1"
+        @test menu.pagesize == 8
+
+        # Fold that the for the pagesize limiting tests next:
+        TerminalMenus.keypress(menu, UInt32(' '))
+
+        # `maxsize` limiting when unfolding:
+
+        menu = TreeMenu(root; dynamic = true, maxsize = 5)
+        state = TerminalMenus.printmenu(io, menu, 2; init = true)
+        str = String(take!(io))
+        nback, lines = linesplitter(str)
+        @test nback == 0
+        @test length(lines) == 3
+        @test lines[2] == " > +  1"
+        @test lines[3] == "      2"
+        @test menu.pagesize == 3
+
+        TerminalMenus.keypress(menu, UInt32(' '))
+        state = TerminalMenus.printmenu(io, menu, 2; init = true)
+        str = String(take!(io))
+        nback, lines = linesplitter(str)
+        @test nback == 0
+        @test length(lines) == 5
+        @test lines[5] == "v      1b"
+        @test menu.pagesize == 5
     end
 end


### PR DESCRIPTION
 Implements a dynamic option to update the pagesize whenever a node is folded or unfolded. Includes a maxsize option as well
 to avoid growing the pagesize too much.

These changes _seem_ to just work, but maybe there's a more elegant way to solve it?