### PR TITLE
Add an option for user-defined key presses

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ One can create very large menus with thousands of options, in which case the men
 and `PgUp`/`PgDn`.
 As described in the `TerminalMenus` documentation, you can customize aspects of the menu's appearance,
 such as the number of items visible simultaneously and the characters used to indicate scrolling and the cursor position.
+`TreeMenu` includes optional keyword arguments `pagesize`, `dynamic`, `maxsize`, and `keypress` to control
+various aspects of the interactive menu. See the docstring for `TreeMenu` for more information.
 
 For `Node` objects where `data` is not an `AbstractString`, you will most likely want to specialize `FoldingTrees.writeoption` for your type.
 See `?FoldingTrees.writeoption` for details.
+

--- a/src/treemenu.jl
+++ b/src/treemenu.jl
@@ -14,11 +14,12 @@ mutable struct TreeMenu{N<:Node} <: TerminalMenus._ConfiguredMenu{TerminalMenus.
     dynamic::Bool
     maxsize::Int
     pageoffset::Int
+    keypress::Any
     config::TerminalMenus.Config
 end
-function TreeMenu(root; pagesize::Int=10, dynamic = false, maxsize = pagesize, kwargs...)
+function TreeMenu(root; pagesize::Int=10, dynamic = false, maxsize = pagesize, keypress = (m,i) -> false, kwargs...)
     pagesize = min(pagesize, count_open_leaves(root))
-    return TreeMenu(root, root, 1, 1, 1, false, pagesize, dynamic, maxsize, 0, TerminalMenus.Config(kwargs...))
+    return TreeMenu(root, root, 1, 1, 1, false, pagesize, dynamic, maxsize, 0, keypress, TerminalMenus.Config(kwargs...))
 end
 
 """
@@ -122,7 +123,7 @@ function TerminalMenus.keypress(menu::TreeMenu, i::UInt32)
             menu.pagesize = min(menu.maxsize, count_open_leaves(menu.root))
         end
     end
-    return false
+    return menu.keypress(menu, i)
 end
 
 function TerminalMenus.selected(menu::TreeMenu)

--- a/src/treemenu.jl
+++ b/src/treemenu.jl
@@ -2,6 +2,18 @@
 
 export TreeMenu
 
+"""
+    TreeMenu(root; pagesize::Int=10, dynamic = false, maxsize = pagesize, keypress = (m,i) -> false, kwargs...)
+
+Use `root` to create an interactive menu using TerminalMenus. `pagesize` is the number of lines to use for a page.
+If `dynamic`, adjust the page size based on the expansion of the content. `maxsize` is the maximum size of the page.
+
+Provide a function `keypress` to respond to keys while the menu is shown. The function has two arguments, `m::TreeMenu`
+and `i::UInt32`. The integer `i` is the key pressed. This function should return `true` if the menu should exit and
+`false` otherwise.
+
+`kwargs` are passed to `TerminalMenus.Config`.
+"""
 mutable struct TreeMenu{N<:Node} <: TerminalMenus._ConfiguredMenu{TerminalMenus.Config}
     root::N
     current::N

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -266,5 +266,22 @@ if isdefined(FoldingTrees, :TreeMenu)
         @test length(lines) == 5
         @test lines[5] == "v      1b"
         @test menu.pagesize == 5
+
+        # Test keypress
+        testint = 1
+        function keypress(menu::TreeMenu, i::UInt32)
+            if i == Int('+')
+                testint += 1
+            elseif i == Int('-')
+                testint -= 1
+            end
+            return false
+        end
+        menu2 = TreeMenu(root, keypress = keypress)
+        TerminalMenus.keypress(menu2, UInt32('+'))
+        @test testint == 2
+        TerminalMenus.keypress(menu2, UInt32('-'))
+        @test testint == 1
+
     end
 end


### PR DESCRIPTION
This adds a keyword argument to provide a function to respond to custom key presses.

This is currently used in [Eyeball.jl](https://github.com/tshort/Eyeball.jl) (using a vendored version). 

I'm not sure if it's best to use `keypress::Any` in the TreeMenu struct.
