### PR TITLE
allow general `IO` argument in `writeline`

### DIFF
--- a/src/treemenu.jl
+++ b/src/treemenu.jl
@@ -117,7 +117,7 @@ TerminalMenus.cancel(menu::TreeMenu) = menu.chosen = false
 
 TerminalMenus.numoptions(menu::TreeMenu) = count_open_leaves(menu.root)
 
-function TerminalMenus.writeline(buf::IOBuffer, menu::TreeMenu, idx::Int, cursor::Bool)
+function TerminalMenus.writeline(buf::IO, menu::TreeMenu, idx::Int, cursor::Bool)
     node = setcurrent!(menu, idx)
     if cursor
         menu.cursoridx = idx


### PR DESCRIPTION
The method for `TerminalMenus.writeline` defined in this package assumes its first argument to be of type `IOBuffer`. The [documentation](https://docs.julialang.org/en/v1/stdlib/REPL/#REPL.TerminalMenus.writeline), however, only guarantees `IO`. Currently `IOBuffer` is used, but I guess there a good chance that this changes to `AnnotatedIOBuffer` if `TerminalMenus` decides to support colors via `StyledStrings`. So it's probably better to stay on the safe side.