### PR TITLE
update `menu.current` before calling `menu.keypress`

### DIFF
--- a/src/treemenu.jl
+++ b/src/treemenu.jl
@@ -128,8 +128,8 @@ function TerminalMenus.writeline(buf::IOBuffer, menu::TreeMenu, idx::Int, cursor
 end
 
 function TerminalMenus.keypress(menu::TreeMenu, i::UInt32)
+    node = setcurrent!(menu, menu.cursoridx)
     if i == Int(' ')
-        node = setcurrent!(menu, menu.cursoridx)
         node.foldchildren = !node.foldchildren
         if menu.dynamic
             menu.pagesize = min(menu.maxsize, count_open_leaves(menu.root))

--- a/src/treemenu.jl
+++ b/src/treemenu.jl
@@ -131,11 +131,12 @@ function TerminalMenus.keypress(menu::TreeMenu, i::UInt32)
     node = setcurrent!(menu, menu.cursoridx)
     if i == Int(' ')
         node.foldchildren = !node.foldchildren
-        if menu.dynamic
-            menu.pagesize = min(menu.maxsize, count_open_leaves(menu.root))
-        end
     end
-    return menu.keypress(menu, i)
+    done = menu.keypress(menu, i)
+    if !done && menu.dynamic
+        menu.pagesize = min(menu.maxsize, count_open_leaves(menu.root))
+    end
+    return done
 end
 
 function TerminalMenus.selected(menu::TreeMenu)


### PR DESCRIPTION
I think it makes sense that `menu.current` points to the current menu item when the user-defined `keypress` function is called for a `TreeMenu`. Currently this is not the case unless the key is space. In this case the current menu item is needed to process the key press correctly, and user-defined `keypress` functions will often be in the same situation.